### PR TITLE
Generate Pokémon with HAs at a 20% rate

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2972,7 +2972,8 @@ void SetBoxMonAbility(void *boxmon) // actually takes boxmon struct as parameter
     pid = GetBoxMonData(boxmon, ID_PARA_personal_rnd, NULL);
     form = GetBoxMonData(boxmon, ID_PARA_form_no, NULL);
 
-    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1)
+    // Set hidden ability at a 20% chance or if the relevant flag is set.
+    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1 || (gf_rand() % 5 == 0))
     {
         SET_BOX_MON_HIDDEN_ABILITY_BIT(boxmon)
         has_hidden_ability = 1;
@@ -3810,7 +3811,8 @@ BOOL GiveMon(int heapId, void *saveData, int species, int level, int forme, u8 a
 
     PokeParaCalc(pokemon); // recalculate stats
 
-    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1)
+    // Set hidden ability at a 20% chance or if the relevant flag is set.
+    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1  || (gf_rand() % 5 == 0))
     {
         SET_MON_HIDDEN_ABILITY_BIT(pokemon)
         // need to clear this script flag because this function is used for in-battle form change ability resets as well, which shouldn't happen normally
@@ -3881,7 +3883,8 @@ BOOL AddWildPartyPokemon(int inTarget, EncounterInfo *encounterInfo, struct Part
         UpdateFormIfDeerling(encounterPartyPokemon);
     }
 
-    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1)
+    // Set hidden ability at a 20% chance or if the relevant flag is set.
+    if (CheckScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG) == 1  || (gf_rand() % 5 == 0))
     {
         SET_MON_HIDDEN_ABILITY_BIT(encounterPartyPokemon)
         ClearScriptFlag(SavArray_Flags_get(SaveBlock2_get()), HIDDEN_ABILITIES_FLAG);


### PR DESCRIPTION
This gives any Pokemon encountered in the wild, from a script encounter or a gift a 20% chance to have its Hidden Ability slot. If it does not, it'll fall back to one of the other two abilities as usual.