### PR TITLE
Modernize Defog effect

### DIFF
--- a/armips/move/battle_sub_seq/171.s
+++ b/armips/move/battle_sub_seq/171.s
@@ -10,72 +10,88 @@
 .create "build/move/battle_sub_seq/1_171", 0
 
 // Defog
+// checksidecondition seems to also clear the effect?
+// If it cannot clear the effect (as it isnt active) it skips to the address given
+// The text currently prints twice if it clears the same effect from both sides
 
 a001_171:
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x0, _00A8
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x1, _00A8
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x2, _00A8
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x3, _00A8
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x4, _00A8
-    checksidecondition BATTLER_DEFENDER, 0x1, 0x5, _00A8
-    if IF_MASK, VAR_SIDE_EFFECT_OPPONENT, 0x80, _00A8
-    if IF_MASK, VAR_FIELD_EFFECT, 0x8000, _00A8
-    goto _00B0
-_00A8:
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x0, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x1, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x2, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x3, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_ATTACKER, 0x1, 0x4, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x4, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_ATTACKER, 0x1, 0x5, _PlayAnimationIfCanClearEffect
+    checksidecondition BATTLER_DEFENDER, 0x1, 0x5, _PlayAnimationIfCanClearEffect
+    if IF_MASK, VAR_SIDE_EFFECT_PLAYER, 0x80, _PlayAnimationIfCanClearEffect
+    if IF_MASK, VAR_SIDE_EFFECT_OPPONENT, 0x80, _PlayAnimationIfCanClearEffect
+    if IF_MASK, VAR_FIELD_EFFECT, 0x8000, _PlayAnimationIfCanClearEffect
+    goto _DropEvasion
+_PlayAnimationIfCanClearEffect:
+    /* This means the animation plays even if the target's evasiveness is minimum */
     gotosubscript 76
-_00B0:
+_DropEvasion:
     changevar VAR_OP_SET, VAR_34, 0x1C
     gotosubscript 12
-    /* Reflect */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x0, _0108
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x0, _0108
+_ReflectOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x0, _LightScreenOpponentSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x0, _LightScreenOpponentSide
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x73
     gotosubscript 172
-_0108:
-    /* Light Screen */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x1, _0148
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x1, _0148
+_LightScreenOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x1, _MistOpponentSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x1, _MistOpponentSide
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x71
     gotosubscript 172
-_0148:
-    /* Mist */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x2, _0188
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x2, _0188
+_MistOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x2, _SafeguardOpponentSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x2, _SafeguardOpponentSide
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x36
     gotosubscript 172
-_0188:
-    /* Safeguard */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x3, _01C8
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x3, _01C8
+_SafeguardOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x3, _SpikesPlayerSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x3, _SpikesPlayerSide
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0xDB
     gotosubscript 172
-_01C8:
-    /* Spikes */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x4, _0218
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x4, _0218
+_SpikesPlayerSide:
+    checksidecondition BATTLER_ATTACKER, 0x0, 0x4, _SpikesOpponentSide
+    checksidecondition BATTLER_ATTACKER, 0x2, 0x4, _SpikesOpponentSide
+    changevar VAR_OP_CLEARMASK, VAR_SIDE_EFFECT_PLAYER, 0x4
+    changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0xBF
+    gotosubscript 172
+_SpikesOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x4, _ToxicSpikesPlayerSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x4, _ToxicSpikesPlayerSide
     changevar VAR_OP_CLEARMASK, VAR_SIDE_EFFECT_OPPONENT, 0x4
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0xBF
     gotosubscript 172
-_0218:
-    /* Toxic Spikes */
-    checksidecondition BATTLER_DEFENDER, 0x0, 0x5, _0258
-    checksidecondition BATTLER_DEFENDER, 0x2, 0x5, _0258
+_ToxicSpikesPlayerSide:
+    checksidecondition BATTLER_ATTACKER, 0x0, 0x5, _ToxicSpikesOpponentSide
+    checksidecondition BATTLER_ATTACKER, 0x2, 0x5, _ToxicSpikesOpponentSide
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x186
     gotosubscript 172
-_0258:
-    /* Stealth Rock */
-    if IF_NOTMASK, VAR_SIDE_EFFECT_OPPONENT, 0x80, _0294
+_ToxicSpikesOpponentSide:
+    checksidecondition BATTLER_DEFENDER, 0x0, 0x5, _StealthRockPlayerSide
+    checksidecondition BATTLER_DEFENDER, 0x2, 0x5, _StealthRockPlayerSide
+    changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x186
+    gotosubscript 172
+_StealthRockPlayerSide:
+    if IF_NOTMASK, VAR_SIDE_EFFECT_PLAYER, 0x80, _StealthRockOpponentSide
+    changevar VAR_OP_CLEARMASK, VAR_SIDE_EFFECT_PLAYER, 0x80
+    changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x1BE
+    gotosubscript 172
+_StealthRockOpponentSide:
+    if IF_NOTMASK, VAR_SIDE_EFFECT_OPPONENT, 0x80, _FogWeather
     changevar VAR_OP_CLEARMASK, VAR_SIDE_EFFECT_OPPONENT, 0x80
     changevar VAR_OP_SET, VAR_MOVE_TEMP2, 0x1BE
     gotosubscript 172
-_0294:
-    /* Foggy Weather */
-    if IF_NOTMASK, VAR_FIELD_EFFECT, 0x8000, _02D8
+_FogWeather:
+    if IF_NOTMASK, VAR_FIELD_EFFECT, 0x8000, _End
     changevar VAR_OP_CLEARMASK, VAR_FIELD_EFFECT, 0x8000
     printmessage 0x415, 0xA, 0x1, 0x1, "NaN", "NaN", "NaN", "NaN"
     waitmessage
     wait 0x1E
-_02D8:
+_End:
     endscript
 
 .close

--- a/data/text/749.txt
+++ b/data/text/749.txt
@@ -430,7 +430,7 @@ The user focuses its\nwillpower to its head\nand rams the foe.\nThis has a 20% c
 The user looses a\nflash of energy from\nits polished body.\nThis has a 30% chance\nto lower accuracy.
 The user gathers all\nits light energy and\nreleases it at once.\nThis has a 10% chance\nto lower Sp. Def.
 A charging attack\nable to scale rocky\nwalls.\nIt has a 20% chance\nto flinch the foe.
-It reduces the foe’s\nevasion stat. It also\nremoves spikes,\nlight screens, etc.
+It reduces the foe’s\nevasion stat. It also\nremoves the foe’s\nbarriers and any\ntraps on the field.
 The user creates a\nbizarre area in which\nslower Pokémon get\nto move first for five\nturns.
 Comets are summoned\ndown from the sky.\nThe attack’s recoil\nsharply reduces the\nuser’s Sp. Atk stat.
 A flare of electricity\nis loosed to strike\nall Pokémon in battle.\nThis has a 30% chance\nto paralyze targets.

--- a/docs/MoveChanges.txt
+++ b/docs/MoveChanges.txt
@@ -239,6 +239,9 @@ The following moves have had their effects updated to work as they do in later g
 - Chatter:
 This now always confuses the opponent.
 
+Defog:
+- This now removes entry hazards (Spikes, Toxic Spikes, Stealth Rock) on both sides of the field instead of just the opponent's.
+
 - Growth:
 This now boosts both Attack and Special Attack by one stage. In sunlight, it boosts them by two stages instead.
 


### PR DESCRIPTION
This changes Defog so it also clears Spikes/Toxic Spikes/Stealth Rock on the player's side of the field as in later generations.

It's not 100% perfect as it'll currently print the same 'blew away xxxx' message twice if the same hazard is on both sides of the field, but it'll do for now.